### PR TITLE
chore: remove textencoder

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const edCurve = require('noise-curve-ed')
 const b4a = require('b4a')
 
 const fetch = require('./fetch/fetch.js')
-const TextDecoder = require('./textdecoder/textdecoder.js')
 
 /**
  * Send request to server
@@ -44,14 +43,12 @@ async function sendRequest ({
   if (!body.result) throw new Error('No result in response')
 
   const result = b4a.from(body.result, 'hex');
-
   const payloadEncrypted = initiator.recv(result);
-
-  const decoder = new TextDecoder();
-  const decoded = decoder.decode(payloadEncrypted);
+  const decoded = b4a.toString(payloadEncrypted);
 
   return JSON.parse(decoded)
 }
+
 module.exports = {
   sendRequest
 }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
     "url": "https://github.com/slashtags/rpc-request/issues"
   },
   "browser": {
-    "./fetch/fetch.js": "./fetch/fetch-browser.js",
-    "./textdecoder/textdecoder.js": "./textdecoder/textdecoder-browser.js"
+    "./fetch/fetch.js": "./fetch/fetch-browser.js"
   },
   "react-native": {
-    "./fetch/fetch.js": "./fetch/fetch-browser.js",
-    "./textdecoder/textdecoder.js": "./textdecoder/textdecoder-browser.js"
+    "./fetch/fetch.js": "./fetch/fetch-browser.js"
   },
   "homepage": "https://github.com/slashtags/rpc-request#readme",
   "dependencies": {

--- a/textdecoder/textdecoder-browser.js
+++ b/textdecoder/textdecoder-browser.js
@@ -1,1 +1,0 @@
-module.exports = globalThis.TextDecoder

--- a/textdecoder/textdecoder.js
+++ b/textdecoder/textdecoder.js
@@ -1,2 +1,0 @@
-const { TextDecoder } = require('util')
-module.exports = TextDecoder


### PR DESCRIPTION
Small cleanup: `textencoder` is not actually needed since we can expect server response to not include any special characters. I tested this in Bitkit.